### PR TITLE
Create helper script to download firmware images

### DIFF
--- a/.release_util/.gitignore
+++ b/.release_util/.gitignore
@@ -1,0 +1,1 @@
+archive.tar.gz

--- a/.release_util/create_archive.sh
+++ b/.release_util/create_archive.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+PWD="$(pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")"; cd ..; pwd)"
+ARCHIVE=$PWD/archive.tar.gz
+
+if [ -f "$ARCHIVE" ]; then
+  echo "$ARCHIVE already exists."
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+tar -czvf "$ARCHIVE" --exclude='*.ltx' plain_bits package.json 
+
+echo "Archive created: $ARCHIVE"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # quel-firmwares
 
+## Getting started
+
+To download firmware images, please run the following command in your terminal:
+
+```sh
+wget -O /tmp/d.sh https://quel-inc.github.io/quel-firmwares/quel_firmware_downloader.sh && chmod +x /tmp/d.sh && /tmp/d.sh
+```
+
+If you have previously downloaded firmware images, this command will replace the old images with the new ones.
+
+The firmwares will be stored in `$XDG_DATA_HOME/quelware/firmwares/`.
+On Linux system, this typically resolves to `~/.local/share/quelware/firmwares/`.
+
+To remove the downloaded files, please run the command above with `-r` option, or manually delete the directory.
+
+### For v0.8.x users
+
+To download firmwares for `v0.8.x`, please run:
+
+```sh
+wget -O /tmp/d.sh https://quel-inc.github.io/quel-firmwares/quel_firmware_downloader.sh && chmod +x /tmp/d.sh && /tmp/d.sh -p for_0.8
+```
+
+
+## For developers
+
 This repository uses [Git LHS](https://git-lfs.com/) to deal with large binary files.
 Make sure to install `git lfs` on your system before working with this repository.
 For installation instructions, please refer to the official [guide](https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&utm_medium=installation_link&utm_campaign=gitlfs#installing).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "packages": [
+    {
+      "name": "default",
+      "directories": [
+        "plain_bits/au200_clockmaster_20240118",
+        "plain_bits/au50_simplemulti_20240125",
+        "plain_bits/zephyr-exstickge_clkdisty_20240731",
+        "plain_bits/zephyr-exstickge_quel1se-fujitsu11-a_20240731",
+        "plain_bits/zephyr-exstickge_quel1se-fujitsu11-b_20240731",
+        "plain_bits/zephyr-exstickge_quel1se-riken8_20240731"
+      ]
+    },
+    {
+      "name": "for_0.8",
+      "directories": [
+        "plain_bits/au200_clockmaster_20240118",
+        "plain_bits/au50_feedback_20240110",
+        "plain_bits/au50_simplemulti_20240125",
+        "plain_bits/zephyr-exstickge_clkdisty_20240731",
+        "plain_bits/zephyr-exstickge_quel1se-fujitsu11-a_20240731",
+        "plain_bits/zephyr-exstickge_quel1se-fujitsu11-b_20240731",
+        "plain_bits/zephyr-exstickge_quel1se-riken8_20240731"
+      ]
+    }
+  ]
+}

--- a/quel_firmware_downloader.sh
+++ b/quel_firmware_downloader.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Download firmware images from a Github release.
+
+set -eu
+
+REPO="quel-inc/quel-firmwares"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/quelware/firmwares"
+TARGZ_TEMP=$(mktemp)
+PACKAGES_JSON_TEMP=$(mktemp)
+
+trap 'rm -f "$TARGZ_TEMP" "$PACKAGES_JSON_TEMP"' EXIT
+
+error_exit() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+download() {
+  _url="$1"
+  _dest="$2"
+  echo "Downloading $(basename "$_url") to $_dest..."
+  curl -L -sSf "$_url" -o "$_dest" || error_exit "Failed to download from $_url"
+}
+
+extract_from_targz() {
+  echo "Extracting specified targets to $_dest..."
+  mkdir -p "$DATA_DIR"
+  cd "$DATA_DIR"
+  while IFS= read -r target; do
+    echo "Extracting $target from $TARGZ_TEMP"
+    tar -xzf "$TARGZ_TEMP" "$target" || error_exit "Failed to extract $target from $TARGZ_TEMP"
+  done
+}
+
+remove_existing_files() {
+  _dir="$1"
+  if [ -d "$_dir" ]; then
+    find "$_dir" -mindepth 1 -delete
+  fi
+}
+
+get_archive_url() {
+  _tag="$1"
+  _api="https://api.github.com/repos/$REPO/releases"
+  if [ -n "$_tag" ]; then
+    _api="${_api}/tags/$_tag"
+  else
+    _api="${_api}/latest"
+  fi
+  curl -sSf "$_api" | jq -r '.assets[] | select(.name | startswith("archive.tar.gz")) | .browser_download_url'
+}
+
+
+show_usage() {
+  cat << EOM >&2
+Downloader of firmware images for QuEL devices.
+
+Usage: $0 [-r] [-p <name>] [-t <tag>] [-y] [-h]
+
+Options:
+  -r            Remove all downloaded firmware images.
+  -p <name>     Specify the name of the package to download directories for.
+  -t <tag>      Specify a release tag to download. If not specified, the latest release is used.
+  -y            Assume yes to all prompts.
+  -h            Show this help message and exit.
+EOM
+}
+
+REMOVE=false
+TAG=
+ASSUME_YES=false
+PACKAGE_NAME="default"
+
+while getopts "rp:t:yh" opt; do
+  case "$opt" in
+    r) REMOVE=true ;;
+    p) PACKAGE_NAME="$OPTARG" ;;
+    t) TAG="$OPTARG" ;;
+    y) ASSUME_YES=true ;;
+    h) show_usage; exit 0 ;;
+    *) show_usage; exit 1 ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ "$REMOVE" = true ]; then
+  echo "Removing firmware images from $DATA_DIR"
+  remove_existing_files "$DATA_DIR"
+  exit 0
+fi
+
+archive_url=$(get_archive_url "$TAG")
+if [ -z "$archive_url" ]; then
+  error_exit "archive.tar.gz file found in the latest/specified release."
+fi
+
+echo "Downloading archive..."
+download "$archive_url" "$TARGZ_TEMP"
+
+echo "Extracting package information..."
+tar -xzf "$TARGZ_TEMP" "package.json" -O > "$PACKAGES_JSON_TEMP" || error_exit "Failed to extract package.json from $TARGZ_TEMP"
+
+directories=$(jq -r ".packages[] | select(.name == \"$PACKAGE_NAME\") | .directories[]" < "$PACKAGES_JSON_TEMP")
+[ -n "$directories" ] || error_exit "No package found with the name $PACKAGE_NAME."
+
+if [ -d "$DATA_DIR" ] && [ -n "$(ls -A "$DATA_DIR")" ]; then
+  response="yes"
+  if [ "$ASSUME_YES" != true ]; then
+    echo "Firmware images already exist in $DATA_DIR. Do you want to replace them? (yes/no) "
+    read -r response
+  fi
+  if [ "$response" != "yes" ]; then
+    echo "Download cancelled."
+    exit 0
+  fi
+  echo "Replacing existing firmware images..."
+  remove_existing_files "$DATA_DIR"
+fi
+echo "Downloading and extracting specified content for package '$PACKAGE_NAME'..."
+echo "$directories" | extract_from_targz
+echo "Specified content downloaded and extracted to $DATA_DIR"


### PR DESCRIPTION
## やったこと

### ダウンロードスクリプト作成

plain_bits以下をダウンロードするスクリプト `quel_firmware_downloader.sh`  を作成しました。

このスクリプトが行うこと
1. GitHubのリリースからarchive.tar.gzをダウンロード (defaultでlatestのリリースが使われる)
2. archive.tar.gzに含まれているpackage.jsonをパースし、`-p`オプションで指定されるpackage name (規定値: default) に対応するディレクトリをarchive.tar.gzから $XDG_DATA_HOME/quelware/firmwares/ に展開する 


* すでに展開されたファイルが存在する場合には、一旦それらのファイルをすべて削除したうえで展開しなおします。
* `-r`オプションをつけると削除のみを行います (uninstall的な動作)
* `-t'でGitHubリリースのタグを指定できます（通常使う想定はないです）

このスクリプトは、`gh-pages`ブランチに置いていてGitHub Pagesでホスティングされているため、README.mdに書かれているように`wget`でダウンロードして実行できます。

### archive.tar.gz を作成するスクリプト作成

`.release_util/create_archive.sh` です。
package.json と plain_bits を archive.tar.gz として固めるだけのスクリプトです。
こうしてできたarchive.tar.gz を、https://github.com/quel-inc/quel-firmwares/releases/tag/20250512 のようにリリースページに登録する流れを想定しています。
前述の通り、ダウンローダーでは特に指定がなければlatestのリリースが使われます。

### package.json 作成

複数のイメージをまとめて パッケージ として扱います。
パッケージ名とイメージを格納したディレクトリの対応関係を宣言するためのものです。

## 背景

plain_bitsディレクトリを独立したリポジトリに分離し、Git LFSを使った管理を始めましたが、

- リポジトリのcloneの際にはあらかじめユーザ環境にGit LFSをインストールする必要がある
- quelwareリポジトリからsubmoduleとして参照することはできるが…
  - cloneと同様にGit LFSのインストールが必要
  - submoduleの扱いには一定のGit慣れが必要なので、バージョンアップでユーザー側がうまく追従できなくなるおそれがある

という問題があります。
 
またユーザにファームウェアイメージを渡す際の問題として、pythonのコードと直接関係ないものをwhlにまとめてしまうことでの煩雑さもあった（コードが共通なのに同封するイメージが違う場合のバージョン管理、など）

そこでPythonパッケージ配布とは別のルートでユーザにplain_bitsを配布する方法の提案として、このPRを作成しました。